### PR TITLE
Bugfix: re-apply of default test case fails due to invalid connection draining timeout setting

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "connection_draining" {
 variable "connection_draining_timeout" {
   description = "Set the timeout value for elastic loadbalancer draining policy if desired."
   type        = "string"
-  default     = 0
+  default     = 300
 }
 
 variable "cookie_expiration_period" {


### PR DESCRIPTION
The initial `terraform apply` on the default test case will successfully create a CLB with `connection_draining = false` disabled and `connection_draining_timeout = 0`:

```
module.clb.aws_elb.clb: Creating...
  arn:                                   "" => "<computed>"
  availability_zones.#:                  "" => "<computed>"
  connection_draining:                   "" => "false"
  connection_draining_timeout:           "" => "0"
```

Terraform _does_ create the CLB with `connection_draining` disabled, but despite the supplied `connection_draining_timeout` value of zero, it creates the CLB with the AWS default connection draining timeout value of `300` seconds.

Re-running `terraform apply` with _**no**_ changes to the templates will prompt Terraform to try to change this value to the configured zero:

```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  ~ module.clb.aws_elb.clb
      connection_draining_timeout: "300" => "0"


Plan: 0 to add, 1 to change, 0 to destroy.
```

... which ends up failing because `0` is not a valid setting for this option:

```
module.clb.aws_elb.clb: Modifying... (ID: gpu6b9umcogwgo4oni-test)
  connection_draining_timeout: "300" => "0"

Error: Error applying plan:

1 error(s) occurred:

* module.clb.aws_elb.clb: 1 error(s) occurred:

* aws_elb.clb: Failure configuring ELB attributes: ValidationError: Time out must be at least 1 second and no more than 3600 seconds
	status code: 400, request id: f5b3e672-d2ed-11e8-90e0-4b05c77be1b7
```

The most sensible solution here IMO is to change the default setting to `300` seconds, which is the AWS default. If `connection_draining` is disabled, then the value is ignored (unless it's invalid). If `connection_draining` _isn't_ disabled, then the consumer will either be updating the timeout setting anyway, or they'll be unsurprised to see that the default is in line with what AWS would normally do anyway.