### PR TITLE
Fix bug involving initial creation w/no instances

### DIFF
--- a/examples/example.tf
+++ b/examples/example.tf
@@ -9,6 +9,7 @@ module "clb" {
   clb_name        = "<name>"
   security_groups = ["sg-01", "sg-02"]
   instances       = ["i-01", "i-02"]
+  instances_count = 2
   subnets         = ["subnet-01", "subnet-02"]
 
   # Optional

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@
  *   clb_name        = "<name>"
  *   security_groups = ["sg-01", "sg-02"]
  *   instances       = ["i-01", "i-02"]
+ *   instances_count = 2
  *   subnets         = ["subnet-01", "subnet-02"]
  *
  *   tags = [{
@@ -104,7 +105,6 @@ resource "aws_elb" "clb" {
   }
 
   subnets                     = ["${var.subnets}"]
-  instances                   = ["${var.instances}"]
   cross_zone_load_balancing   = "${var.cross_zone}"
   idle_timeout                = "${var.idle_timeout}"
   connection_draining         = "${var.connection_draining}"
@@ -117,6 +117,12 @@ resource "aws_autoscaling_attachment" "asg_attachment_bar" {
   count                  = "${var.asg_target != "" ? 1:0}"
   autoscaling_group_name = "${var.asg_target}"
   elb                    = "${aws_elb.clb.id}"
+}
+
+resource "aws_elb_attachment" "instance" {
+  count    = "${var.instances_count}"
+  elb      = "${aws_elb.clb.id}"
+  instance = "${var.instances[count.index]}"
 }
 
 resource "aws_lb_cookie_stickiness_policy" "clb_lb_policy" {

--- a/tests/default/minimal.tf
+++ b/tests/default/minimal.tf
@@ -91,6 +91,7 @@ module "clb" {
   clb_name        = "${random_string.rstring.result}-test"
   security_groups = ["${aws_security_group.test_sg1.id}", "${aws_security_group.test_sg2.id}"]
   instances       = ["${aws_instance.test01.id}", "${aws_instance.test02.id}"]
+  instances_count = 2
 
   tags = [{
     "Right" = "Said"

--- a/variables.tf
+++ b/variables.tf
@@ -128,6 +128,13 @@ variable "health_check_unhealthy_threshold" {
 variable "instances" {
   description = "A list of EC2 instance IDs for the load balancer. Use when not assigned to auto scale group. i.e. ['i-0806906515f952316', 'i-0806906515f952316', 'i-0806906515f952316']"
   type        = "list"
+  default     = []
+}
+
+variable "instances_count" {
+  description = "Total number of individual instances to attach to this CLB. Must match actual count of the `instances` parameter."
+  type        = "string"
+  default     = 0
 }
 
 variable "create_internal_record" {


### PR DESCRIPTION
Attach individual EC2 instances using the `aws_elb_attachment` resource instead, making this module support both ASG and individual EC2 attachments (or neither).

**WARNING:** This introduces a potential BC break, as the `instances_count` variable is required in order to workaround Terraform's inability to iterate over potentially dynamic lists within a module. Since this module is still on major version 0, however, BC breaks without a major version bump should be OK.