### PR TITLE
Update to proper dimension for unhealthyhost

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ module "unhealthy_host_count_alarm" {
   unit                     = "Count"
 
   dimensions = [{
-    LoadBalancer = "${aws_elb.clb.id}"
+    LoadBalancerName = "${aws_elb.clb.id}"
   }]
 }
 


### PR DESCRIPTION
##### Corresponding Issue(s):
https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/234

##### Summary of change(s):
fix bad unhealthyhost  - from LoadBalancer to LoadBalancerName
##### Reason for Change(s):
- the alarm reports as insufficient state, indefinitely 
- See issue



No
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No
##### If input variables or output variables have changed or has been added, have you updated the README?
n/a

##### Do examples need to be updated based on changes?
no.
