### PR TITLE
updating `instances_count` type and minimum aws provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 
 | Name | Version |
 |------|---------|
-| aws | >= 2.1.0 |
+| aws | >= 2.7.0 |
 
 ## Inputs
 
@@ -62,7 +62,7 @@ Using [aws-terraform-cloudwatch\_alarm](https://github.com/rackspace-infrastruct
 | health\_check\_unhealthy\_threshold | Consecutive failed checks before marking instance unhealthy. | `number` | `3` | no |
 | idle\_timeout | The time (in seconds) that a connection to the load balancer can remain idle, which means no data is sent over the connection. After the specified time, the load balancer closes the connection. Value from 1 - 4000 | `number` | `60` | no |
 | instances | A list of EC2 instance IDs for the load balancer. Use when not assigned to auto scale group. i.e. ['i-0806906515f952316', 'i-0806906515f952316', 'i-0806906515f952316'] | `list(string)` | `[]` | no |
-| instances\_count | Total number of individual instances to attach to this CLB. Must match actual count of the `instances` parameter. | `string` | `""` | no |
+| instances\_count | Total number of individual instances to attach to this CLB. Must match actual count of the `instances` parameter. | `number` | `0` | no |
 | internal\_loadbalancer | If true, CLB will be an internal CLB. | `bool` | `false` | no |
 | internal\_record\_name | Record Name for the new Resource Record in the Internal Hosted Zone | `string` | `""` | no |
 | internal\_zone\_id | The Route53 Internal Hosted Zone ID | `string` | `""` | no |

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "aws" {
   region  = "us-west-2"
-  version = "~> 2.1"
+  version = "~> 2.7"
 }
 
 module "clb" {

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    aws = ">= 2.1.0"
+    aws = ">= 2.7.0"
   }
 }
 

--- a/tests/default/main.tf
+++ b/tests/default/main.tf
@@ -4,7 +4,7 @@ terraform {
 
 provider "aws" {
   region  = "us-west-2"
-  version = "~> 2.2"
+  version = "~> 2.7"
 }
 
 resource "random_string" "rstring" {

--- a/variables.tf
+++ b/variables.tf
@@ -108,8 +108,8 @@ variable "instances" {
 
 variable "instances_count" {
   description = "Total number of individual instances to attach to this CLB. Must match actual count of the `instances` parameter."
-  type        = string
-  default     = ""
+  type        = number
+  default     = 0
 }
 
 variable "internal_loadbalancer" {


### PR DESCRIPTION
##### Corresponding Issue(s):
- none

##### Summary of change(s):
- bumped minimum aws provider to 2.7 for best 0.12.0  compatibility
- changed `instances_count` type to number since its's used in  resource counts
##### Reason for Change(s):
- leaving to default leads to  build failure.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
no
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
no
##### If input variables or output variables have changed or has been added, have you updated the README?
yes
##### Do examples need to be updated based on changes?
no
