### PR TITLE
Move logging bucket policy to data document

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,6 +53,19 @@ data "aws_caller_identity" "current_identity" {
 data "aws_elb_service_account" "main" {
 }
 
+data "aws_iam_policy_document" "clb_bucket_policy" {
+  version = "2012-10-17"
+  statement {
+    actions   = ["s3:PutObject"]
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.log_bucket[0].arn}/*"]
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_elb_service_account.main.arn]
+    }
+  }
+}
+
 locals {
   acl_list = ["authenticated-read", "aws-exec-read", "bucket-owner-read", "bucket-owner-full-control", "log-delivery-write", "private", "public-read", "public-read-write"]
   env_list = ["Development", "Integration", "PreProduction", "Production", "QA", "Staging", "Test"]
@@ -195,27 +208,7 @@ resource "aws_s3_bucket_policy" "log_bucket_policy" {
 
   bucket = aws_s3_bucket.log_bucket[0].id
 
-  policy = <<POLICY
-{
-  "Id": "Policy1529427095432",
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Action": [
-        "s3:PutObject"
-      ],
-      "Effect": "Allow",
-      "Resource": "${aws_s3_bucket.log_bucket[0].arn}/*",
-      "Principal": {
-        "AWS": [
-          "${data.aws_elb_service_account.main.arn}"
-        ]
-      }
-    }
-  ]
-}
-POLICY
-
+  policy = data.aws_iam_policy_document.clb_bucket_policy.json
 }
 
 # enable cloudwatch/RS ticket creation

--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,8 @@ data "aws_elb_service_account" "main" {
 }
 
 data "aws_iam_policy_document" "clb_bucket_policy" {
+  count = var.create_logging_bucket ? 1 : 0
+
   version = "2012-10-17"
   statement {
     actions   = ["s3:PutObject"]
@@ -208,7 +210,7 @@ resource "aws_s3_bucket_policy" "log_bucket_policy" {
 
   bucket = aws_s3_bucket.log_bucket[0].id
 
-  policy = data.aws_iam_policy_document.clb_bucket_policy.json
+  policy = data.aws_iam_policy_document.clb_bucket_policy[0].json
 }
 
 # enable cloudwatch/RS ticket creation


### PR DESCRIPTION
* Instead of a here doc, a data block using iam_policy_document is used to declare permissions for the logging bucket if one is created

Testing was done by adjusting the current test to create the S3 logging bucket and validating the s3 bucket permission JSON looks proper. Sample output:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::999999999999:root"
            },
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::terraform-123456789/*"
        }
    ]
}
```

##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.
